### PR TITLE
Added additional custom date field

### DIFF
--- a/MigratorWordpress.module
+++ b/MigratorWordpress.module
@@ -44,6 +44,7 @@ class MigratorWordpress extends MigratorAbstract implements Module, Configurable
           ),
           'field' => array(
                 'title'      => 'title',
+                'date'       => 'date',
                 'body'       => 'body',
                 'headline'   => 'headline',
                 'images'     => 'images',
@@ -744,6 +745,7 @@ class MigratorWordpress extends MigratorAbstract implements Module, Configurable
         // the pw-fields content
         $return['data'] = array(
             $this->customNames['field']['title']             => $post['post_title'],
+            $this->customNames['field']['date']              => $post['post_date_gmt'],
             $this->customNames['field']['body']              => $this->markupBody($post['post_content']),
             $this->customNames['field']['images']            => array(),
             $this->customNames['field']['files']             => array(),
@@ -779,6 +781,7 @@ class MigratorWordpress extends MigratorAbstract implements Module, Configurable
         // the pw-fields content
         $return['data'] = array(
             $this->customNames['field']['title']             => $page['post_title'],
+            $this->customNames['field']['date']              => $post['post_date_gmt'],
             $this->customNames['field']['body']              => $this->markupBody($page['post_content']),
             $this->customNames['field']['images']            => array(),
             $this->customNames['field']['files']             => array(),
@@ -1098,6 +1101,12 @@ private function inlineCaption($text) {
             $field->name = 'field_title';
             $field->label = "title";
             $field->value = ((isset($data['field_title'])) ?  $data['field_title'] : 'title');
+            $fields->add($field);
+
+            $field = wire('modules')->get('InputfieldText');
+            $field->name = 'field_date';
+            $field->label = 'date';
+            $field->value = ((isset($data['field_date'])) ?  $data['field_date'] : 'date');
             $fields->add($field);
 
             $field = wire('modules')->get('InputfieldText');


### PR DESCRIPTION
This field is for the datetime that the blog post is published. This is
different to the created and modified PW fields. At the moment I am
populating this with the post_date_gmt - is this appropriate?

As well as being a good idea in general, I also wanted this field
because Kongondo's blog module requires it is filled out. Although for
compatibility with that, the config setting needs to be changed to
blog_date.
