### PR TITLE
Fixes an issue that threw an "Class Comments not found" error message.

### DIFF
--- a/MigratorWordpress.module
+++ b/MigratorWordpress.module
@@ -933,6 +933,8 @@ class MigratorWordpress extends MigratorAbstract implements Module, Configurable
 
 
     private function convertComments($comments){
+        // Include Comments class (just to be sure)
+        $this->modules->get("FieldtypeComments");
         //All comments code thanks to Okeowo Aderemi
 
         //We are expecting an array of comments


### PR DESCRIPTION
The error is thrown if the Comment class hasn't been included at runtime. It is fixed by explicitly including the FieldtypeComments module that contains the Comments class.